### PR TITLE
Auth implementation for sockets channels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ EXPOSE 8080
 
 CMD ["python", "src/app.py"]
 
-# docker build -t transcription-service .
-# docker run -it -p 10000:10000 --name transcription-container transcription-service
+# docker build -t tsi-feb7 . && docker run -it -p 8080:8080 --name tsc-feb7 tsi-feb7
+# docker container rm tsc-feb7 && docker image rm tsi-feb7
 
 # docker build --platform linux/amd64,linux/arm64 -t tsi2 . 
 # docker tag e2d059d76f8d us-west2-docker.pkg.dev/omega-dahlia-394021/tsi/backend-image

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ python-socketio==5.3.0
 aiohttp==3.7.4.post0
 google-cloud-speech==2.5.0
 google-cloud-translate==2.0.1
+firebase-admin==5.0.0


### PR DESCRIPTION
#### Background
This is a python application that exposes a simple REST interface using `aiohttp` and a less simple collection of WebSockets channels using `python-socketio`.  The application is now being deployed in Google Compute Engine on a VM with a public IP, so it needs auth.

What's in the PR?
`python-socketio` has some pretty rudimentary, but nice [auth features ](https://python-socketio.readthedocs.io/en/latest/server.html#connect-and-disconnect-events) built in. This PR uses those features to define authentication logic in the `connect` channels: `connect/object` and `connect/subject`.

[Firebase Authentication](https://firebase.google.com/docs/auth/admin/verify-id-tokens#verify_id_tokens_using_the_firebase_admin_sdk) is used for the actual authentication step. The client, which is using one of socketio's client SDKs, includes a JWT in the bundle of data used to initiate the connection. This app grabs the JWT and verifies it using `firebase_admin.auth.verify_id_token()`. If the token isn't valid for a user in Firebase, an exception is thrown. Otherwise, the connection is opened.
