### PR TITLE
tee stdout/stderr to log file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,27 @@
 FROM python:3.10-bookworm
 ENV GOOGLE_SERVICE_JSON_FILE=google-services.json
 
+# Create a directory for logs
+RUN mkdir -p /var/log/interp
+
+COPY entrypoint.sh .
+RUN chmod +x entrypoint.sh
 COPY requirements.txt .
-RUN pip install -r requirements.txt
 COPY google-services.json .
 COPY ./src ./src
 
+RUN pip install -r requirements.txt
 EXPOSE 8080
+ENTRYPOINT ["/entrypoint.sh"]
 
-CMD ["python", "src/app.py"]
+###################################
+# Running locally:
+###################################
+# docker container rm tsc-local && docker image rm tsi-local && docker build -t tsi-local . && docker run -it -p 8080:8080 --name tsc-local tsi-local
 
-# docker build -t tsi-feb7 . && docker run -it -p 8080:8080 --name tsc-feb7 tsi-feb7
-# docker container rm tsc-feb7 && docker image rm tsi-feb7
-
-# docker build --platform linux/amd64,linux/arm64 -t tsi2 . 
-# docker tag e2d059d76f8d us-west2-docker.pkg.dev/omega-dahlia-394021/tsi/backend-image
+###################################
+# Pushing to GCP Artifact Registry:
+###################################
+# docker build --platform linux/amd64,linux/arm64 -t tsi . 
+# docker tag tsi us-west2-docker.pkg.dev/omega-dahlia-394021/tsi/backend-image
 # docker push us-west2-docker.pkg.dev/omega-dahlia-394021/tsi/backend-image 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Create a log file with a timestamp
+LOG_FILE="/var/log/interp/interp_$(date +'%Y-%m-%d_%H-%M-%S').log"
+echo "entrypoint.sh - $(date +'%Y-%m-%d_%H-%M-%S')" | tee -a $LOG_FILE
+
+# Run the app and tee the output
+python -u src/app.py 2>&1 | tee -a $LOG_FILE


### PR DESCRIPTION
### Background
Compute Engine doesn't automatically redirect `stdout` to any of GCP's logging features. So when this app is running in the cloud, none of the it's `print()` output is visible anywhere.

I considered these 3 approaches:
1. Using the `google-cloud-logging` [library](https://cloud.google.com/logging/docs/setup/python) in the app
2. Logging to a file and using a [logging agent](https://cloud.google.com/logging/docs/agent/logging/configuration) to send its content to Google Cloud Logging
3. Use [Docker Logging Drivers](https://docs.docker.com/engine/logging/configure/) to send logs to Google Cloud Logging 

### Approach
This PR writes logs to a file. Reasoning:
- Low complexity (this is a low priority atm)
- Can optionally be extended later with a logging agent

### What's in the PR?
Now teeing `stdout` and `stderr` to a log file. This will allow logs to be viewed in the terminal when run locally or in GCP by  tailing the log file in an `ssh` shell.

#### Additional changes
- Made Dockerfile comments more useful